### PR TITLE
Resolve some NU1608 warnings in the Avalonia.Microcharts

### DIFF
--- a/src/Avalonia.Microcharts.Example/Avalonia.Microcharts.Example.csproj
+++ b/src/Avalonia.Microcharts.Example/Avalonia.Microcharts.Example.csproj
@@ -19,7 +19,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Avalonia.Desktop" Version="0.9.1" />
+      <PackageReference Include="Avalonia.Desktop" Version="0.10.0" />
     </ItemGroup>
 
 

--- a/src/Avalonia.Microcharts/Avalonia.Microcharts.csproj
+++ b/src/Avalonia.Microcharts/Avalonia.Microcharts.csproj
@@ -5,8 +5,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Avalonia.Desktop" Version="0.9.1" />
-      <PackageReference Include="SkiaSharp" Version="1.68.1" />
+      <PackageReference Include="Avalonia.Desktop" Version="0.10.0" />
+      <PackageReference Include="SkiaSharp" Version="2.80.3" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Hi, I found some NU1608 warnings in the Avalonia.Microcharts:

`Warning NU1608 Detected package version outside of dependency constraint: Avalonia.Skia.Linux.Natives 1.68.0.2 requires SkiaSharp (= 1.68.0) but version SkiaSharp 1.68.1 was resolved.`

This fix can remove this warnings from Avalonia.Microcharts's dependency graph.
Hope the PR can help you.

Best regards,
sucrose